### PR TITLE
Add schema_based_diagram.sql file

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ vet_clinic=# CREATE TABLE animals (
 
 👤 **Dani Morillo**
 
-- GitHub: [danifromecuador](https://github.com/francksefu)
-- Twitter: [@danifromecuador](https://twitter.com/franck_sefu)
-- LinkedIn: [danifromecuador](https://www.linkedin.com/in/franck-sefu-884705254/)
+- GitHub: [danifromecuador](https://github.com/danifromecuador)
+- Twitter: [@danifromecuador](https://twitter.com/danifromecuador)
+- LinkedIn: [danifromecuador](https://www.linkedin.com/in/danifromecuador)
 
 👤 **Franck Sefu**
 - GitHub: [franksefu1998](https://github.com/francksefu)

--- a/schema_based_diagram.sql
+++ b/schema_based_diagram.sql
@@ -1,0 +1,62 @@
+CREATE DATABASE clinic;
+CREATE TABLE patients(
+    id INT GENERATED ALWAYS AS IDENTITY,
+    name VARCHAR(60),
+    date_of_birth DATE,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE medical_histories(
+    id INT GENERATED ALWAYS AS IDENTITY,
+    admitted_at TIMESTAMP,
+    patient_id INT,
+    status VARCHAR(60),
+    CONSTRAINT fk_patient FOREIGN KEY (patient_id) REFERENCES patients(id),
+    PRIMARY KEY(id)
+);
+
+CREATE TABLE treatments (
+    id INT,
+    type VARCHAR(50),
+    name VARCHAR (60),
+    PRIMARY KEY(id)
+);
+
+CREATE TABLE invoices(
+    id INT GENERATED ALWAYS AS IDENTITY,
+    total_amount DECIMAL(11, 5),
+    generated_at TIMESTAMP,
+    payed_at TIMESTAMP,
+    medical_histories_id INT,
+    CONSTRAINT fk_medical FOREIGN KEY(medical_histories_id) REFERENCES medical_histories(id),
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE invoice_items (
+    id INT GENERATED ALWAYS AS IDENTITY,
+    unit_price DEC(11, 5),
+    quantity INT,
+    total_price DEC(11, 5),
+    invoice_id INT,
+    treatment_id INT,
+    CONSTRAINT fk_invoices FOREIGN KEY(invoice_id) REFERENCES invoices(id),
+    CONSTRAINT fk_treatment FOREIGN KEY(treatment_id) REFERENCES treatments(id),
+    PRIMARY KEY(id)
+);
+
+CREATE TABLE medical_treatment(
+    medical_histories_id INT,
+    treatment_id INT,
+    CONSTRAINT fk_treatment FOREIGN KEY(treatment_id) REFERENCES treatments(id),
+    CONSTRAINT fk_medical FOREIGN KEY(medical_histories_id) REFERENCES medical_histories(id),
+    PRIMARY KEY(medical_histories_id, treatment_id) 
+);
+
+-- Add indexes 
+CREATE INDEX idx_patient ON patients(name);
+CREATE INDEX idx_medical ON medical_histories(admitted_at);
+CREATE INDEX idx_treatment ON treatments(name);
+CREATE INDEX idx_invoice ON invoice_items(invoice_id);
+CREATE INDEX idx_treatment_item ON invoice_items(treatment_id);
+CREATE INDEX idx_medical_treatment_treatment_id ON medical_treatment(treatment_id);
+CREATE INDEX idx_invoices_medical_histories_id ON invoices(medical_histories_id);


### PR DESCRIPTION
Take a look at the following database diagram for a clinic:
Clinic diagram
![clinic_diagram](https://github.com/danifromecuador/vet-clinic/assets/90141102/3f16a1a8-dc63-4ea1-9f0b-3873aafbcffa)

Create a file named schema_based_on_diagram.sql where you implement the database from the diagram.
Join tables from many-to-many relationships might not appear in the diagram, but you still need them.
Remember to add the FK indexes.